### PR TITLE
ci(release): remove unnecessary install/prepack scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
       - uses: actions/setup-node@v4
         with:
           node-version: "18.x"
@@ -23,6 +22,4 @@ jobs:
         # Currently, only npm supports publishing packages with provenance
         # https://docs.npmjs.com/generating-provenance-statements
         run: |
-          bun install
-          bun prepack
           npm publish --provenance --access public


### PR DESCRIPTION
d099e747640b0c9a4a2209b7fa3ab1fea4eeb965 updated the workflow so that generated files are now checked into source control.

This means the `bun install; bun prepack` scripts in the release workflow are no longer needed.