### PR TITLE
chore(deps-dev): upgrade typescript to 5.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@carbon/pictograms": "12.46.0",
         "@types/bun": "latest",
         "culls": "^0.1.1",
-        "svelte": "^5.20.1",
+        "svelte": "^5.20.4",
         "typescript": "latest",
       },
     },
@@ -66,7 +66,7 @@
 
     "svelte": ["svelte@5.20.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@jridgewell/sourcemap-codec": "^1.5.0", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "acorn-typescript": "^1.4.13", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^1.4.3", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-2Mo/AfObaw9zuD0u1JJ7sOVzRCGcpETEyDkLbtkcctWpCMCIyT0iz83xD8JT29SR7O4SgswuPRIDYReYF/607A=="],
 
-    "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+    "typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import buildInfo from "@carbon/pictograms/metadata.json" assert { type: "json" };
+import buildInfo from "@carbon/pictograms/metadata.json" with { type: "json" };
 import { $ } from "bun";
-import { devDependencies, name } from "../package.json" assert { type: "json" };
-import { template } from "./template";
+import pkg from "../package.json" with { type: "json" };
+import { template } from "./template.js";
 
 export const buildPictograms = async () => {
   console.time("Built in");
@@ -40,11 +40,11 @@ export type CarbonPictogramProps = SvelteHTMLElements["svg"] & {
     );
   });
 
-  const packageMetadata = `${pictograms.length} pictograms from @carbon/pictograms@${devDependencies["@carbon/pictograms"]}`;
+  const packageMetadata = `${pictograms.length} pictograms from @carbon/pictograms@${pkg.devDependencies["@carbon/pictograms"]}`;
 
   await Bun.write(
     "lib/index.d.ts",
-    `// Type definitions for ${name}
+    `// Type definitions for ${pkg.name}
 // ${packageMetadata}
 
 ${definitions}`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
+    "erasableSyntaxOnly": true,
     "esModuleInterop": true,
     "lib": ["esnext", "DOM"],
     "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "strict": true,
     "paths": {


### PR DESCRIPTION
Enable `erasableSyntaxOnly` and `module: "nodenext"`, and fix TS errors.